### PR TITLE
Add recommended extensions for the vscode workspace

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,9 @@
+{
+    // See http://go.microsoft.com/fwlink/?LinkId=827846
+    // for the documentation about the extensions.json format
+    "recommendations": [
+        // Extension identifier format: ${publisher}.${name}. Example: vscode.csharp
+        "esbenp.prettier-vscode",
+        "eg2.tslint"
+    ]
+}


### PR DESCRIPTION
See https://code.visualstudio.com/docs/editor/extension-gallery#_workspace-recommended-extensions

This change will make vscode automatically recommended the extensions needed (currently prettier and tslint) rather than us listing them out in the README.